### PR TITLE
fix(): `globalAlpha`, `transform`, `setTransform`

### DIFF
--- a/canvas2pdf.js
+++ b/canvas2pdf.js
@@ -198,10 +198,11 @@ const PDFDocument = require("pdfkit");
 
     Object.defineProperty(this, "globalAlpha", {
       get: function () {
-        return _this.doc.opacity();
+        return _this.__globalAlpha ?? 1;
       },
       set: function (value) {
-        value >= 0.0 && value <= 1.0 && _this.doc.opacity(value);
+        _this.__globalAlpha = Math.max(0.0, Math.min(value, 1.0));
+        _this.doc.opacity(_this.__globalAlpha);
       },
     });
 
@@ -257,6 +258,28 @@ const PDFDocument = require("pdfkit");
 
   canvas2pdf.PdfContext.prototype.translate = function (x, y) {
     this.doc.translate(x, y);
+  };
+
+  canvas2pdf.PdfContext.prototype.transform = function (
+    a = 1,
+    b = 0,
+    c = 0,
+    d = 1,
+    e = 0,
+    f = 0
+  ) {
+    this.doc.transform(a, b, c, d, e, f);
+  };
+
+  canvas2pdf.PdfContext.prototype.setTransform = function (
+    a = 1,
+    b = 0,
+    c = 0,
+    d = 1,
+    e = 0,
+    f = 0
+  ) {
+    this.doc._ctm = [a, b, c, d, e, f];
   };
 
   canvas2pdf.PdfContext.prototype.beginPath = function () {
@@ -558,9 +581,6 @@ const PDFDocument = require("pdfkit");
   /**
    * Not yet implemented
    */
-  canvas2pdf.PdfContext.prototype.setTransform = function () {
-    console.log("setTransform not implemented");
-  };
 
   canvas2pdf.PdfContext.prototype.createPattern = function (image, repetition) {
     console.log("createPattern not implemented");


### PR DESCRIPTION
Hello there!
I am not sure this fork is maintained.
Anyways I will give it a shot.
If not please let me know (and save me time if this lib is worthless by saying so).
`globalAlpha` getter was retuning a ref to the doc - fixed that by keeping it in state.
Implemented `transform`, `setTransform`.


